### PR TITLE
Update urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This utility allows users to validate STAC json files against the [STAC](https://github.com/radiantearth/stac-spec) spec or against local STAC extensions.
 
 It can be installed as command line utility and passed either a local file path or a url along with the STAC version to validate against. 
-Example usages can be found below
+Example usages can be found below.
 
 
 ## Requirements

--- a/tests/test_stac_validator.py
+++ b/tests/test_stac_validator.py
@@ -21,7 +21,7 @@ def _run_validate(
 @pytest.mark.item
 def test_item_master():
     stac = _run_validate(
-        url="https://raw.githubusercontent.com/radiantearth/stac-spec/master/item-spec/examples/sample-full.json"
+        url="https://raw.githubusercontent.com/radiantearth/stac-spec/v0.6.1/item-spec/examples/sample.json"
     )
     assert stac.status == {
         "catalogs": {"valid": 0, "invalid": 0},

--- a/tests/test_stac_validator.py
+++ b/tests/test_stac_validator.py
@@ -19,7 +19,7 @@ def _run_validate(
 
 
 @pytest.mark.item
-def test_item_master():
+def test_item_v061_remote():
     stac = _run_validate(
         url="https://raw.githubusercontent.com/radiantearth/stac-spec/v0.6.1/item-spec/examples/sample.json"
     )
@@ -92,9 +92,9 @@ def test_local_schema_item():
 
 
 @pytest.mark.catalog
-def test_catalog_master():
+def test_catalog_v061_remote():
     stac = _run_validate(
-        url="https://raw.githubusercontent.com/radiantearth/stac-spec/master/catalog-spec/examples/catalog.json"
+        url="https://raw.githubusercontent.com/radiantearth/stac-spec/v0.6.1/catalog-spec/examples/catalog.json"
     )
     assert stac.status == {
         "catalogs": {"valid": 1, "invalid": 0},
@@ -184,9 +184,9 @@ def test_local_schema_catalog_schema_fail():
 
 
 @pytest.mark.collection
-def test_collection_master():
+def test_collection_v061_remote():
     stac = _run_validate(
-        "https://raw.githubusercontent.com/radiantearth/stac-spec/master/collection-spec/examples/sentinel2.json"
+        "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.6.1/collection-spec/examples/sentinel2.json"
     )
     assert stac.status == {
         "catalogs": {"valid": 0, "invalid": 0},


### PR DESCRIPTION
The master schemas have updated paths so we need to add the tags to the urls for the test fixtures.