### PR TITLE
Reworded error message for local schema catalog schema test.

### DIFF
--- a/tests/test_stac_validator.py
+++ b/tests/test_stac_validator.py
@@ -174,7 +174,7 @@ def test_local_schema_catalog_schema_fail():
         {
             "asset_type": "catalog",
             "valid_stac": False,
-            "error_message": "'stac_version' is a required property of []",
+            "error_message": "'stac_version' is a required property of the root of the STAC object.",
             "path": "tests/test_data/good_catalog_v052.json",
         }
     ]


### PR DESCRIPTION
Closes [Issue 34](https://github.com/sparkgeo/stac-validator/issues/34). Follows [PR 60](https://github.com/sparkgeo/stac-validator/pull/60) currently under review.

I noticed the issue is no longer valid in the `dev` branch and is reworded in PR 60, so maybe it's better to close Issue 34?