### PR TITLE
Remove unnecessary top level __init__.py.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,0 @@
-"""
-Description:
-
-"""
-__author__ = "James Banting"
-


### PR DESCRIPTION
The author field is already in `setup.py`.

This `__init__.py` confuses some packaging tools.