### PR TITLE
Handle relative paths in case the cusom JSON Schema is a valid local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install stac-validator
 Description: Validate a STAC item or catalog against the STAC specification.
 
 Usage:
-    stac_validator <stac_file> [--version STAC_VERSION] [--timer] [--recursive] [--log_level LOGLEVEL] [--custom CUSTOM] [--update] [--force] [--extension EXTENSION] [--core] [--legacy] 
+    stac_validator <stac_file> [--version STAC_VERSION] [--timer] [--recursive] [--log_level LOGLEVEL] [--custom CUSTOM] [--update] [--force] [--extension EXTENSION] [--core] [--legacy] [--with_error_code]
 
 Arguments:
     stac_file  Fully qualified path or url to a STAC file.
@@ -55,6 +55,7 @@ Options:
     --extension EXTENSION        Validate an extension
     --core                       Validate on core only
     --legacy                     Validate on older schemas, must be accompanied by --version
+    --with_error_code            Return a non-zero exit code in case of a failure during validation
 ```  
 
 ## versions supported

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -301,7 +301,18 @@ class StacValidate:
         try:
             if(self.custom):
                 schema, _ = self.fetch_and_parse_file(self.custom)
-                jsonschema.validate(stac_content, schema)
+                
+                # in case the path to custom json schema is local
+                # it may contain relative references
+                if(os.path.exists(self.custom)):
+                    custom_abspath = os.path.abspath(self.custom)
+                    custom_dir = os.path.dirname(custom_abspath).replace('\\', '/')
+                    custom_uri = f'file:///{custom_dir}/'
+                    resolver = RefResolver(custom_uri, self.custom)
+                    jsonschema.validate(stac_content, schema, resolver=resolver)
+                else:
+                    jsonschema.validate(stac_content, schema)
+
                 self.message.append(message)
                 message['schema'] = self.custom
                 message["custom"] = True

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -2,7 +2,7 @@
 Description: Validate a STAC item or catalog against the STAC specification.
 
 Usage:
-    stac_validator <stac_file> [--version STAC_VERSION] [--timer] [--recursive] [--log_level LOGLEVEL] [--custom CUSTOM] [--update] [--force] [--extension EXTENSION] [--core] [--legacy] 
+    stac_validator <stac_file> [--version STAC_VERSION] [--timer] [--recursive] [--log_level LOGLEVEL] [--custom CUSTOM] [--update] [--force] [--extension EXTENSION] [--core] [--legacy] [--with_error_code] 
 
 Arguments:
     stac_file  Fully qualified path or url to a STAC file.
@@ -19,6 +19,7 @@ Options:
     --extension EXTENSION        Validate an extension
     --core                       Validate on core only
     --legacy                     Validate on older schemas, must be accompanied by --version
+    --with_error_code            Return a non-zero exit code in case of a failure during validation
 """
 
 import json
@@ -41,6 +42,7 @@ from pystac.validation import STACValidationError
 from pystac import Item, Catalog, Collection
 from jsonschema import RefResolutionError, RefResolver, validate
 from jsonschema.exceptions import ValidationError
+from functools import reduce
 
 logger = logging.getLogger(__name__)
 
@@ -445,6 +447,7 @@ def main():
     core = args.get("--core")
     legacy = args.get("--legacy")
     custom = args.get("--custom")
+    with_error_code = args.get("--with_error_code")
 
     if timer:
         start = default_timer()
@@ -458,6 +461,9 @@ def main():
 
     if timer:
         print(f"Validator took {default_timer() - start:.2f} seconds")
+
+    if with_error_code and (not reduce(lambda l, r: l and r, [m['valid_stac'] for m in stac.message])):
+        exit(1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hey everyone, I faced an issue that I can't validate STAC Items with against a custom local schema with relative paths. This PR fixes the behavior. I hope it works for you as well!

This PR adds a local resolver in case the custom schema is a valid local path.

It also introduces a flag that changes the script error codes behavior: when enabled, the non zero exit code would be returned in case of the validation failure.

### Demo: 

* Commit that shows local schema check: https://github.com/azavea/stac-layer/pull/1/commits/38039c301c57a19d6049311b176f7062e71a5366
* The CI run: https://github.com/azavea/stac-layer/runs/2009800691
* The CI run with the correct error codes returned: https://github.com/azavea/stac-layer/runs/2010007893 (happy failed CI run!)

Closes #53