### PR TITLE
 Native type checks - bypass pystac type checking for newer versions 

### DIFF
--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -40,6 +40,9 @@ class StacValidate:
 
     def get_stac_type(self, stac_content: dict) -> str:
         try:
+            content_types = ["Item", "Catalog", "Collection"]
+            if "type" in stac_content and stac_content["type"] in content_types:
+                return stac_content["type"]
             stac_object = identify_stac_object(stac_content)
             return stac_object.object_type
         except TypeError as e:


### PR DESCRIPTION
Resolves: https://github.com/sparkgeo/stac-validator/issues/99